### PR TITLE
Update PATCO URL

### DIFF
--- a/feed_sources/Patco.py
+++ b/feed_sources/Patco.py
@@ -6,7 +6,7 @@ import requests
 
 from FeedSource import FeedSource, TIMECHECK_FMT
 
-URL = 'https://addtransit.com/gtfs/Patco/PortAuthorityTransitCorporation.zip'
+URL = 'http://www.ridepatco.org/developers/PortAuthorityTransitCorporation.zip'
 FILE_NAME = 'patco.zip'
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Old URL is still valid, but has outdated feed.
Note there is now a developers page: http://www.ridepatco.org/developers/