### PR TITLE
Scrape PATCO URL

### DIFF
--- a/feed_sources/Patco.py
+++ b/feed_sources/Patco.py
@@ -3,10 +3,11 @@
 from datetime import datetime
 import logging
 import requests
+from bs4 import BeautifulSoup
 
 from FeedSource import FeedSource, TIMECHECK_FMT
 
-URL = 'http://www.ridepatco.org/developers/PortAuthorityTransitCorporation.zip'
+DEVPAGE_URL = 'http://www.ridepatco.org/developers/'
 FILE_NAME = 'patco.zip'
 
 LOG = logging.getLogger(__name__)
@@ -16,5 +17,23 @@ class Patco(FeedSource):
     """Fetch official PATCO feed."""
     def __init__(self):
         super(Patco, self).__init__()
-        self.urls = {'patco.zip': URL}
+        url = self.find_download_url()
+        if url:
+            self.urls = {'patco.zip': url}
+        else:
+            LOG.error('Could not scrape PATCO GTFS download URL from developer page')
+            self.urls = {}
 
+    def find_download_url(self):
+        """Helper to scrape developer's page for the download URL, which changes"""
+        devpage = requests.get(DEVPAGE_URL)
+        soup = BeautifulSoup(devpage.text, 'html.parser')
+        rt = soup.find(id='rightcolumn')
+        anchors = rt.findAll('a')
+        for anchor in anchors:
+            href = anchor.attrs['href']
+            if href.endswith('.zip'):
+                return href
+
+        # if got this far, no GTFS download link found
+        return None


### PR DESCRIPTION
PATCO GTFS URL changes with each release.
Scrape the developer info page to find out what it is currently.