### PR TITLE
Add a Dockerfile to encapsulate dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2
+
+RUN mkdir -p /usr/local/src
+WORKDIR /usr/local/src
+
+COPY requirements.txt /usr/local/src/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/local/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  gtfs-feed-fetcher:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/usr/local/src


### PR DESCRIPTION
Encapsulate the project dependencies in a container image so that working installations of Python 2.x are not necessary on the host workstation.

Connects https://github.com/azavea/geospatial-apps/pull/250

---

**Testing**

The following commands should all complete successfully:

```console
$ docker-compose build
$ docker-compose run --rm gtfs-feed-fetcher ./fetch_feeds.py --feeds=Septa,Patco,Delaware,NJTransit --get-nj
$ docker-compose run --rm gtfs-feed-fetcher ./extend_effective_dates.py --feeds=patco.zip,septa_bus.zip,septa_rail.zip,dart.zip
```