### PR TITLE
Drop NJTransit login and add performance

### DIFF
--- a/FeedSource.py
+++ b/FeedSource.py
@@ -283,14 +283,13 @@ class FeedSource(object):
             LOG.debug('Time check entry for %s not found.', file_name)
             return 0
 
-    def download(self, file_name, url, do_stream=True, session=None):
+    def download(self, file_name, url, do_stream=True):
         """Download feed.
 
         :param file_name: File name to save download as, relative to :ddir:
         :param url: Where to download the GTFS from
         :param do_stream: If True, stream the download
-        :param session: If set, the open session within which to send the request
-        :returns: True if download was successful
+                :returns: True if download was successful
         """
         LOG.debug('In get_stream to get file %s from URL %s.', file_name, url)
         if self.check_header_newer(url, file_name) == -1:
@@ -298,16 +297,13 @@ class FeedSource(object):
             return False
         # file_name is local to download directory
         file_path = os.path.join(self.ddir, file_name)
-        LOG.info('Getting file %s...', file_path)
-        if not session:
-            request = requests.get(url, stream=do_stream)
-        else:
-            request = session.get(url, stream=do_stream)
+        LOG.info('Getting file %s...from...%s', file_path, url)
+        request = requests.get(url, stream=do_stream)
 
         if request.ok:
             with open(file_path, 'wb') as download_file:
                 if do_stream:
-                    for chunk in request.iter_content():
+                    for chunk in request.iter_content(chunk_size=1024):
                         download_file.write(chunk)
                 else:
                     download_file.write(request.content)

--- a/feed_sources/NJTransit.py
+++ b/feed_sources/NJTransit.py
@@ -6,14 +6,11 @@ an email is sent to the developer account saying new feeds are available.
 """
 import logging
 
-import requests
-
 from FeedSource import FeedSource
 
 
 LOG = logging.getLogger(__name__)
 
-LOGIN_URL = 'https://www.njtransit.com/users/login'
 URL = 'https://www.njtransit.com/'
 
 
@@ -22,7 +19,7 @@ class NJTransit(FeedSource):
     def __init__(self):
         super(NJTransit, self).__init__()
         self.urls = {'nj_rail.zip': URL + 'rail_data.zip', 'nj_bus.zip': URL + 'bus_data.zip'}
-        self.nj_payload = {} # need to set username and password in this to log in
+
 
     def fetch(self):
         """Fetch NJ TRANSIT bus and rail feeds.
@@ -30,14 +27,9 @@ class NJTransit(FeedSource):
         First logs on to create session before fetching and validating downloads.
         """
         for filename in self.urls:
-            session = requests.Session()
-            login = session.post(LOGIN_URL, data=self.nj_payload)
-            if login.ok:
-                LOG.debug('Logged in to NJ TRANSIT successfully.')
-                url = self.urls.get(filename)
-                self.fetchone(filename, url, session=session)
-                self.write_status()
-            else:
-                LOG.error('Failed to log in to NJ TRANSIT. Response status: %s: %s.',
-                          login.status_code, login.reason)
-            session.close()
+            url = self.urls.get(filename)
+            self.fetchone(filename, url)
+            self.write_status()
+
+
+

--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -55,19 +55,19 @@ def fetch_all(sources=None):
 
     for file_name in statuses:
         stat = statuses[file_name]
-        if stat.has_key('error'):
-            LOG.error('Error processing %s: %s', file_name, stat['error'])
-            continue
         msg = []
         msg.append(file_name)
         msg.append('x' if stat.has_key('is_new') and stat['is_new'] else '')
         msg.append('x' if stat.has_key('is_valid') and stat['is_valid'] else '')
         msg.append('x' if stat.has_key('is_current') and stat['is_current'] else '')
         msg.append('x' if stat.has_key('newly_effective') and stat.get('newly_effective') else '')
-
+        if stat.has_key('error'):
+             msg.append(stat['error'])
+        else:
+             msg.append('')
         ptable.add_row(msg)
 
-    ptable.field_names = ['file', 'new?', 'valid?', 'current?', 'newly effective?']
+    ptable.field_names = ['file', 'new?', 'valid?', 'current?', 'newly effective?', 'error']
     LOG.info('Results:\n%s', ptable.get_string())
     LOG.info('All done!')
 


### PR DESCRIPTION
The URLs are publicly accessible and are what Transit.land uses as well
https://github.com/transitland/transitland-atlas/blob/master/feeds/nj-transit.dmfr.json

I checked if the downloads are the same with or without logins and they are.

Drop all the NJTransit specific bits including session handling.

Adds chuck_size to substancially increase download performance, overall time taken
was reduced from 30m to 12m when running wiht Septa,Patco,Delaware,NJTransit. This
was unrelated to the above but in my testing downloads above I noted that the python
requests code could use some improvements.

- [ ] Update the deployment README ["Getting the GTFS Files"](https://github.com/azavea/geospatial-apps/blob/master/gophillygo_deployment.md#getting-the-gtfs-files) section to reflect these changes.