### PR TITLE
Fix septa_rail not being validated if septa_bus failed validation

### DIFF
--- a/feed_sources/Septa.py
+++ b/feed_sources/Septa.py
@@ -92,15 +92,14 @@ class Septa(FeedSource):
                         bus_good = True
                     else:
                         LOG.warn('SEPTA bus GTFS verification failed.')
-                        return False
                     if self.verify(RAIL_FILE):
                         rail_good = True
                     else:
                         LOG.warn('SEPTA rail GTFS verification failed.')
-                        return False
                     if rail_good and bus_good:
                         LOG.info('SEPTA bus and rail verification succeeded.')
                         return True
+                    return False
                 else:
                     LOG.error('Could not find SEPTA GTFS files with expected names.')
                     return False


### PR DESCRIPTION
This PR fixes the `septa_rail.zip` file not being verified at all if the `septa_bus.zip` verification failed. This was ok for a while, but now that `septa_bus.zip` consistently fails due to inconsistent newline characters in a few of its files, I've been having to validate `septa_rail.zip` individually. This saves a couple of steps during the deployment process.